### PR TITLE
Fix branch in version file URLs

### DIFF
--- a/GameData/DART/Version/DART.version
+++ b/GameData/DART/Version/DART.version
@@ -1,8 +1,8 @@
 {
     "NAME":"DART-Project",
-    "URL":"https://raw.githubusercontent.com/Galileo88/DART-Project/master/GameData/DART/Version/DART.version",
+    "URL":"https://raw.githubusercontent.com/Galileo88/DART-Project/main/GameData/DART/Version/DART.version",
     "DOWNLOAD":"https://github.com/Galileo88/DART-Project/releases",
-    "CHANGE_LOG_URL":"https://raw.githubusercontent.com/Galileo88/DART-Project/master/GameData/DART/Version/Changelog.md",
+    "CHANGE_LOG_URL":"https://raw.githubusercontent.com/Galileo88/DART-Project/main/GameData/DART/Version/Changelog.md",
     "VERSION":{
         "MAJOR":1,
         "MINOR":0,


### PR DESCRIPTION
Hi @Galileo88 and @OhioBob,

This repo is using a `main` branch instead of `master`. Now the URLs in the version file are updated to match.